### PR TITLE
Update defaults.js

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -33,8 +33,6 @@ export function globalDefaults(options) {
 }
 
 export function dataDefaults(options, bigOptions = {}) {
-	options = cloneDeep(options)
-
 	if (typeof options === 'function') {
 		options = { get: options }
 	}


### PR DESCRIPTION
Removed cloneDeep in line 36 - this was causing a typeerror

cloneDeep always returned an object.